### PR TITLE
wrap Stream volume argument in double quotes

### DIFF
--- a/docker/platerec_installer.py
+++ b/docker/platerec_installer.py
@@ -938,7 +938,7 @@ def submit_stream(config, n_clicks, token, key, home, boot, videocontent,
                 pull_docker(STREAM_IMAGE)
             command = f'docker run {autoboot} -t ' \
                       f'{nvidia} --name stream ' \
-                      f'-v {home}:{USER_DATA} ' \
+                      f'-v "{home}:{USER_DATA}" ' \
                       f'{user_info} ' \
                       f'-e LICENSE_KEY={key} ' \
                       f'-e TOKEN={token} ' \


### PR DESCRIPTION
The -v  must be generated in quotes "command" so that bash, powershell or CMD accepts the command without error.