### PR TITLE
Reduce Blur Processing Time For Videos

### DIFF
--- a/video-editor/requirements.txt
+++ b/video-editor/requirements.txt
@@ -2,3 +2,4 @@ opencv-python==4.5.5.64
 requests==2.31.0
 flask==2.3.2
 ffmpegcv==0.3.6
+scipy==1.11.2


### PR DESCRIPTION
## Feature Description
1. This [script](https://github.com/parkpow/deep-license-plate-recognition/blob/master/video-editor/video_editor.py) is used to blur videos but is currently slow because it runs plate detection on every frame using the [blur api](https://guides.platerecognizer.com/docs/blur/blur-images#upload-images)

2. Reduce the processing time by skipping some frames when uploading for plate detection then interpolating bounding boxes of intermediate frames based on bounding boxes from uploaded frames

## TODO
- [ ] Interpolate blur mask between frames
- [ ] Blur in script using mask instead of blur API
- [ ] Test performance