### PR TITLE
fix-error-usernameNXintegration

### DIFF
--- a/webhooks/Webhook_nx/README.md
+++ b/webhooks/Webhook_nx/README.md
@@ -30,7 +30,7 @@ Start the server
 python3 main.py <parameter>
 
 example:
-python3 main.py --server_host "https://192.168.5.10:7001" --port 5001 --username admin --password admin123
+python3 main.py --server_host "https://192.168.5.10:7001" --port 5001 --login admin --password admin123
 
 ```
 
@@ -42,7 +42,7 @@ Optional parameters:
 
 Required parameters:
 
-- --username
+- --login
 - --password
 
 For external access
@@ -92,7 +92,7 @@ To run the script in a docker container, use the procedure below:
    ```bash
     example:
 
-    docker run --rm -t -p 5000:5000 --SERVER_HOST "https://192.168.5.10:7001" -e USERNAME=admin -e PASSWORD=admin123 platerecognizer/webhook-vms
+    docker run --rm -t -p 5000:5000 --SERVER_HOST "https://192.168.5.10:7001" -e LOGIN=admin -e PASSWORD=admin123 platerecognizer/webhook-vms
     
    ```
 
@@ -112,6 +112,6 @@ Required parameters:
 ```bash
 example:
 
-docker run --rm -t -p 5000:5000 --SERVER_HOST "https://192.168.5.10:7001" -e USERNAME=admin -e PASSWORD=admin123 -e TAG=Authorized -e PARKPOW_TOKEN=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY  platerecognizer/webhook-vms
+docker run --rm -t -p 5000:5000 --SERVER_HOST "https://192.168.5.10:7001" -e LOGIN=admin -e PASSWORD=admin123 -e TAG=Authorized -e PARKPOW_TOKEN=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY  platerecognizer/webhook-vms
 
 ```

--- a/webhooks/Webhook_nx/main.py
+++ b/webhooks/Webhook_nx/main.py
@@ -159,9 +159,8 @@ if __name__ == "__main__":
     args.tag = os.getenv("TAG", args.tag)
     args.parkpow_token = os.getenv("PARKPOW_TOKEN", args.parkpow_token)
 
-
     if server_host is None or args.password is None or args.login is None:
-        logging.error("Variables server_host, password and login are required.")
+        logging.error("Missing required configuration: server_host, password, and login must be set.")
         sys.exit(1)
 
     if args.debug:

--- a/webhooks/Webhook_nx/main.py
+++ b/webhooks/Webhook_nx/main.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
 
 
     if server_host is None or args.password is None or args.login is None:
-        logging.error("Variables server_host, password and usarname are required.")
+        logging.error("Variables server_host, password and login are required.")
         sys.exit(1)
 
     if args.debug:

--- a/webhooks/Webhook_nx/main.py
+++ b/webhooks/Webhook_nx/main.py
@@ -30,7 +30,7 @@ def convert_to_timestamp_milliseconds(time_string):
 def session_create(args):
     url = f"{server_host}/rest/v2/login/sessions"
     payload = {
-        "username": args.username,
+        "username": args.login,
         "password": args.password,
         "setCookie": True
     }
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=5000, help="The port number to bind the server to. (Optional - Default = 5000)")
     parser.add_argument("--debug", action="store_true", help="Turn on Flask debug mode. (Optional)")
     parser.add_argument("--server_host", type=str, help="Server host")
-    parser.add_argument("--username", type=str, help="username")
+    parser.add_argument("--login", type=str, help="login")
     parser.add_argument("--password", type=str, help="password")
     parser.add_argument("--ssl", type=bool, default=False, help="Enable ssl verification (boolean)")
     parser.add_argument("--parkpow_token", type=str, help="Token Parkpow")
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     server_host = os.getenv("SERVER_HOST", args.server_host)
-    args.username = os.getenv("USERNAME", args.username)
+    args.login = os.getenv("LOGIN", args.login)
     args.password = os.getenv("PASSWORD", args.password)
     args.ssl = os.getenv("SSL", args.ssl)
     args.debug = os.getenv("DEBUG", args.debug)
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     args.parkpow_token = os.getenv("PARKPOW_TOKEN", args.parkpow_token)
 
 
-    if server_host is None or args.password is None or args.username is None:
+    if server_host is None or args.password is None or args.login is None:
         logging.error("Variables server_host, password and usarname are required.")
         sys.exit(1)
 

--- a/webhooks/Webhook_nx/main.py
+++ b/webhooks/Webhook_nx/main.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=5000, help="The port number to bind the server to. (Optional - Default = 5000)")
     parser.add_argument("--debug", action="store_true", help="Turn on Flask debug mode. (Optional)")
     parser.add_argument("--server_host", type=str, help="Server host")
-    parser.add_argument("--login", type=str, help="login")
+    parser.add_argument("--login", type=str, help="login (user name)")
     parser.add_argument("--password", type=str, help="password")
     parser.add_argument("--ssl", type=bool, default=False, help="Enable ssl verification (boolean)")
     parser.add_argument("--parkpow_token", type=str, help="Token Parkpow")


### PR DESCRIPTION
Note: Sorry for the typo in the branch name.

For some reason, when using a username argument on Windows, the user account name is captured, interfering with the information passed to the script.