### PR TITLE
fix(error when no plate and detection mode vehicle)

### DIFF
--- a/plate_recognition.py
+++ b/plate_recognition.py
@@ -140,6 +140,7 @@ def flatten_dict(d, parent_key="", sep="_"):
 
 def flatten(result):
     plates = result["results"]
+    del result["results"]
     if "usage" in result:
         del result["usage"]
     flattened_data = []  # Accumulate flattened data for each plate
@@ -148,7 +149,6 @@ def flatten(result):
         data.update(flatten_dict({}))  # Assuming flatten_dict can handle an empty dict
         flattened_data.append(data)
     else:
-        del result["results"]
         for plate in plates:
             data = result.copy()
             data.update(flatten_dict(plate))


### PR DESCRIPTION
As im mostly testing images with our SDK, for quite some time if vehicles with no plate and detection mode is set to vehicle, our pr script returns an error.

To go over this, I added a way to generalize and make the csv output the same for both detection modes, this way it will be easier to analyze regardless of the detection mode set. 

Also it fixes the unusual adding of newlines for every row. And also if there is no detections for the image, it will still log it in the file.

![Screenshot 2025-02-17 212348](https://github.com/user-attachments/assets/b5f2644f-d522-4387-bc62-2e88a867697a)

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced plate recognition to handle 'vehicle' detection mode when no plates are detected.
- New Feature: Introduced `transform_result` function for improved result data structure analysis.
- Refactor: Updated `flatten` function to manage empty plate results effectively.
- Refactor: Modified `save_results` to utilize new functions for transforming and flattening results before saving in CSV format.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->