### PR TITLE
feat: make blur -b option optional

### DIFF
--- a/blur/main.py
+++ b/blur/main.py
@@ -178,7 +178,7 @@ Specify engine config and/or two regions:
         "-b",
         "--blur-url",
         help="Url to blur SDK. Example http://localhost:5000",
-        required=True,
+        default="https://blur.platerecognizer.com/v1/blur",
     )
     parser.add_argument(
         "--images",

--- a/blur/main.py
+++ b/blur/main.py
@@ -168,9 +168,9 @@ def main():
         description="Blur plates and faces in a folder recursively",
         epilog="""Examples:
 Process images from a folder:
-  python main.py -b=http://localhost:8001 --images=/path/to/images
+  python main.py -b=http://localhost:8001/v1/blur --images=/path/to/images
 Specify engine config and/or two regions:
-  python main.py -b=http://localhost:8001 --config='{"region":"strict"}' -r us-ca -r th-37 --images=/path/to/images""",
+  python main.py -b=http://localhost:8001/v1/blur --config='{"region":"strict"}' -r us-ca -r th-37 --images=/path/to/images""",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument("-a", "--api-key", help="Your API key.", required=False)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Made the `--blur-url` option optional in the command-line interface by setting a default value (`https://blur.platerecognizer.com/v1/blur`). This enhancement simplifies usage by allowing users to omit the `-b` or `--blur-url` option unless a custom URL is needed, improving user experience and flexibility.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->